### PR TITLE
refactor: simplify tool handlers with extracted helpers

### DIFF
--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -1,11 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-// Import types from generated client
 import type {
 	GetV1RoutineFolders200,
 	GetV1RoutineFoldersFolderid200,
 	PostV1RoutineFolders201,
-	RoutineFolder,
 } from "../generated/client/types/index.js";
 import { withErrorHandling } from "../utils/error-handler.js";
 import { formatRoutineFolder } from "../utils/formatters.js";
@@ -52,11 +50,7 @@ export function registerFolderTools(
 				pageSize,
 			});
 
-			// Process routine folders to extract relevant information
-			const folders =
-				data?.routine_folders?.map((folder: RoutineFolder) =>
-					formatRoutineFolder(folder),
-				) || [];
+			const folders = data?.routine_folders?.map(formatRoutineFolder) || [];
 
 			if (folders.length === 0) {
 				return createEmptyResponse(
@@ -136,10 +130,7 @@ export function registerFolderTools(
 			}
 
 			const folder = formatRoutineFolder(data);
-			return createJsonResponse(folder, {
-				pretty: true,
-				indent: 2,
-			});
+			return createJsonResponse(folder);
 		}, "create-routine-folder"),
 	);
 }

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -7,9 +7,6 @@ import type {
 	PostRoutinesRequestSet,
 	PostRoutinesRequestSetTypeEnumKey,
 	PostV1Routines201,
-	PutRoutinesRequestExercise,
-	PutRoutinesRequestSet,
-	PutRoutinesRequestSetTypeEnumKey,
 	PutV1RoutinesRoutineid200,
 	Routine,
 } from "../generated/client/types/index.js";
@@ -20,6 +17,7 @@ import { parseJsonArray } from "../utils/json-parser.js";
 import {
 	createEmptyResponse,
 	createJsonResponse,
+	type McpToolResponse,
 } from "../utils/response-formatter.js";
 import type { InferToolParams } from "../utils/tool-helpers.js";
 import { convertWeightToKg } from "../utils/weight-conversion.js";
@@ -143,6 +141,73 @@ const routineExerciseSchema = z.object({
 	sets: z.array(routineSetSchema),
 });
 
+type RoutineExerciseInput = z.infer<typeof routineExerciseSchema>;
+
+interface RoutineExercisesResult {
+	exercises: PostRoutinesRequestExercise[];
+	usesRepRanges: boolean;
+}
+
+function mapRoutineExercises(
+	exercises: RoutineExerciseInput[],
+): RoutineExercisesResult {
+	let usesRepRanges = false;
+
+	const mapped = exercises.map((exercise): PostRoutinesRequestExercise => {
+		const sets = exercise.sets.map((set): PostRoutinesRequestSet => {
+			const repRange = buildRepRange(set.repRange);
+			const fixedReps = getFixedRepsFromRepRange(repRange);
+			const reps = typeof set.reps === "number" ? set.reps : fixedReps;
+			return {
+				type: set.type as PostRoutinesRequestSetTypeEnumKey,
+				weight_kg: convertWeightToKg(set),
+				reps: reps ?? null,
+				distance_meters: set.distance ?? set.distanceMeters ?? null,
+				duration_seconds: set.duration ?? set.durationSeconds ?? null,
+				custom_metric: set.customMetric ?? null,
+				rep_range: repRange,
+			};
+		});
+
+		if (
+			sets.some(
+				(set) =>
+					set.rep_range != null &&
+					getFixedRepsFromRepRange(set.rep_range) === null,
+			)
+		) {
+			usesRepRanges = true;
+		}
+
+		return {
+			exercise_template_id: exercise.exerciseTemplateId,
+			superset_id: exercise.supersetId ?? null,
+			rest_seconds: exercise.restSeconds ?? null,
+			notes: exercise.notes ?? null,
+			sets,
+		};
+	});
+
+	return { exercises: mapped, usesRepRanges };
+}
+
+function buildRoutineResponse(
+	data: Routine,
+	usesRepRanges: boolean,
+): McpToolResponse {
+	const routine = formatRoutine(data);
+	const response = createJsonResponse(routine);
+
+	if (usesRepRanges) {
+		response.content.push({
+			type: "text",
+			text: repRangeDisplayWarningText,
+		});
+	}
+
+	return response;
+}
+
 /**
  * Register all routine-related tools with the MCP server
  */
@@ -173,9 +238,7 @@ export function registerRoutineTools(
 				pageSize,
 			});
 
-			// Process routines to extract relevant information
-			const routines =
-				data?.routines?.map((routine: Routine) => formatRoutine(routine)) || [];
+			const routines = data?.routines?.map(formatRoutine) || [];
 
 			if (routines.length === 0) {
 				return createEmptyResponse(
@@ -208,9 +271,8 @@ export function registerRoutineTools(
 				);
 			}
 			const { routineId } = args;
-			const data: GetV1RoutinesRoutineid200 = await hevyClient.getRoutineById(
-				String(routineId),
-			);
+			const data: GetV1RoutinesRoutineid200 =
+				await hevyClient.getRoutineById(routineId);
 			if (!data || !data.routine) {
 				return createEmptyResponse(`Routine with ID ${routineId} not found`);
 			}
@@ -238,47 +300,15 @@ export function registerRoutineTools(
 					"API client not initialized. Please provide HEVY_API_KEY.",
 				);
 			}
-			const { title, folderId, notes, exercises } = args;
-			let usesRepRanges = false;
+			const { title, folderId, notes, exercises: rawExercises } = args;
+			const { exercises, usesRepRanges } = mapRoutineExercises(rawExercises);
+
 			const data: PostV1Routines201 = await hevyClient.createRoutine({
 				routine: {
 					title,
 					folder_id: folderId ?? null,
 					notes: notes ?? "",
-					exercises: exercises.map((exercise): PostRoutinesRequestExercise => {
-						const sets = exercise.sets.map((set): PostRoutinesRequestSet => {
-							const repRange = buildRepRange(set.repRange);
-							const fixedReps = getFixedRepsFromRepRange(repRange);
-							const reps = typeof set.reps === "number" ? set.reps : fixedReps;
-							return {
-								type: set.type as PostRoutinesRequestSetTypeEnumKey,
-								weight_kg: convertWeightToKg(set),
-								reps: reps ?? null,
-								distance_meters: set.distance ?? set.distanceMeters ?? null,
-								duration_seconds: set.duration ?? set.durationSeconds ?? null,
-								custom_metric: set.customMetric ?? null,
-								rep_range: repRange,
-							};
-						});
-
-						if (
-							sets.some(
-								(set) =>
-									set.rep_range != null &&
-									getFixedRepsFromRepRange(set.rep_range) === null,
-							)
-						) {
-							usesRepRanges = true;
-						}
-
-						return {
-							exercise_template_id: exercise.exerciseTemplateId,
-							superset_id: exercise.supersetId ?? null,
-							rest_seconds: exercise.restSeconds ?? null,
-							notes: exercise.notes ?? null,
-							sets,
-						};
-					}),
+					exercises,
 				},
 			});
 
@@ -288,20 +318,7 @@ export function registerRoutineTools(
 				);
 			}
 
-			const routine = formatRoutine(data);
-			const response = createJsonResponse(routine, {
-				pretty: true,
-				indent: 2,
-			});
-
-			if (usesRepRanges) {
-				response.content.push({
-					type: "text",
-					text: repRangeDisplayWarningText,
-				});
-			}
-
-			return response;
+			return buildRoutineResponse(data, usesRepRanges);
 		}, "create-routine"),
 	);
 
@@ -324,49 +341,16 @@ export function registerRoutineTools(
 					"API client not initialized. Please provide HEVY_API_KEY.",
 				);
 			}
-			const { routineId, title, notes, exercises } = args;
-			let usesRepRanges = false;
+			const { routineId, title, notes, exercises: rawExercises } = args;
+			const { exercises, usesRepRanges } = mapRoutineExercises(rawExercises);
+
 			const data: PutV1RoutinesRoutineid200 = await hevyClient.updateRoutine(
 				routineId,
 				{
 					routine: {
 						title,
 						notes: notes ?? null,
-						exercises: exercises.map((exercise): PutRoutinesRequestExercise => {
-							const sets = exercise.sets.map((set): PutRoutinesRequestSet => {
-								const repRange = buildRepRange(set.repRange);
-								const fixedReps = getFixedRepsFromRepRange(repRange);
-								const reps =
-									typeof set.reps === "number" ? set.reps : fixedReps;
-								return {
-									type: set.type as PutRoutinesRequestSetTypeEnumKey,
-									weight_kg: convertWeightToKg(set),
-									reps: reps ?? null,
-									distance_meters: set.distance ?? set.distanceMeters ?? null,
-									duration_seconds: set.duration ?? set.durationSeconds ?? null,
-									custom_metric: set.customMetric ?? null,
-									rep_range: repRange,
-								};
-							});
-
-							if (
-								sets.some(
-									(set) =>
-										set.rep_range != null &&
-										getFixedRepsFromRepRange(set.rep_range) === null,
-								)
-							) {
-								usesRepRanges = true;
-							}
-
-							return {
-								exercise_template_id: exercise.exerciseTemplateId,
-								superset_id: exercise.supersetId ?? null,
-								rest_seconds: exercise.restSeconds ?? null,
-								notes: exercise.notes ?? null,
-								sets,
-							};
-						}),
+						exercises,
 					},
 				},
 			);
@@ -377,20 +361,7 @@ export function registerRoutineTools(
 				);
 			}
 
-			const routine = formatRoutine(data);
-			const response = createJsonResponse(routine, {
-				pretty: true,
-				indent: 2,
-			});
-
-			if (usesRepRanges) {
-				response.content.push({
-					type: "text",
-					text: repRangeDisplayWarningText,
-				});
-			}
-
-			return response;
+			return buildRoutineResponse(data, usesRepRanges);
 		}, "update-routine"),
 	);
 }

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -141,7 +141,6 @@ export function registerTemplateTools(
 					pageSize,
 				});
 
-			// Process exercise templates to extract relevant information
 			const templates =
 				data?.exercise_templates?.map(formatExerciseTemplate) || [];
 

--- a/src/tools/workouts.ts
+++ b/src/tools/workouts.ts
@@ -44,6 +44,45 @@ const workoutExerciseSchema = z.object({
 	sets: z.array(workoutSetSchema),
 });
 
+type WorkoutFields = {
+	title: string;
+	description?: string | null;
+	startTime: string;
+	endTime: string;
+	isPrivate: boolean;
+	exercises: z.infer<typeof workoutExerciseSchema>[];
+};
+
+function buildWorkoutPayload(fields: WorkoutFields): PostWorkoutsRequestBody {
+	const { title, description, startTime, endTime, isPrivate, exercises } =
+		fields;
+	return {
+		workout: {
+			title,
+			description: description ?? null,
+			start_time: startTime,
+			end_time: endTime,
+			is_private: isPrivate,
+			exercises: exercises.map(
+				(exercise): PostWorkoutsRequestExercise => ({
+					exercise_template_id: exercise.exerciseTemplateId,
+					superset_id: exercise.supersetId ?? null,
+					notes: exercise.notes ?? null,
+					sets: exercise.sets.map((set) => ({
+						type: set.type as PostWorkoutsRequestSetTypeEnumKey,
+						weight_kg: convertWeightToKg(set),
+						reps: set.reps ?? null,
+						distance_meters: set.distance ?? set.distanceMeters ?? null,
+						duration_seconds: set.duration ?? set.durationSeconds ?? null,
+						rpe: (set.rpe as PostWorkoutsRequestSetRpeEnumKey | null) ?? null,
+						custom_metric: set.customMetric ?? null,
+					})),
+				}),
+			),
+		},
+	};
+}
+
 /**
  * Register all workout-related tools with the MCP server
  */
@@ -74,8 +113,7 @@ export function registerWorkoutTools(
 				pageSize,
 			});
 
-			const workouts =
-				data?.workouts?.map((workout) => formatWorkout(workout)) || [];
+			const workouts = data?.workouts?.map(formatWorkout) || [];
 
 			if (workouts.length === 0) {
 				return createEmptyResponse(
@@ -199,32 +237,7 @@ export function registerWorkoutTools(
 					"API client not initialized. Please provide HEVY_API_KEY.",
 				);
 			}
-			const { title, description, startTime, endTime, isPrivate, exercises } =
-				args;
-			const workoutPayload: NonNullable<PostWorkoutsRequestBody["workout"]> = {
-				title,
-				description: description ?? null,
-				start_time: startTime,
-				end_time: endTime,
-				is_private: isPrivate,
-				exercises: exercises.map(
-					(exercise): PostWorkoutsRequestExercise => ({
-						exercise_template_id: exercise.exerciseTemplateId,
-						superset_id: exercise.supersetId ?? null,
-						notes: exercise.notes ?? null,
-						sets: exercise.sets.map((set) => ({
-							type: set.type as PostWorkoutsRequestSetTypeEnumKey,
-							weight_kg: convertWeightToKg(set),
-							reps: set.reps ?? null,
-							distance_meters: set.distance ?? set.distanceMeters ?? null,
-							duration_seconds: set.duration ?? set.durationSeconds ?? null,
-							rpe: (set.rpe as PostWorkoutsRequestSetRpeEnumKey | null) ?? null,
-							custom_metric: set.customMetric ?? null,
-						})),
-					}),
-				),
-			};
-			const requestBody: PostWorkoutsRequestBody = { workout: workoutPayload };
+			const requestBody = buildWorkoutPayload(args);
 
 			const data: PostV1Workouts201 =
 				await hevyClient.createWorkout(requestBody);
@@ -236,10 +249,7 @@ export function registerWorkoutTools(
 			}
 
 			const workout = formatWorkout(data);
-			return createJsonResponse(workout, {
-				pretty: true,
-				indent: 2,
-			});
+			return createJsonResponse(workout);
 		}, "create-workout"),
 	);
 
@@ -265,39 +275,8 @@ export function registerWorkoutTools(
 					"API client not initialized. Please provide HEVY_API_KEY.",
 				);
 			}
-			const {
-				workoutId,
-				title,
-				description,
-				startTime,
-				endTime,
-				isPrivate,
-				exercises,
-			} = args;
-			const workoutPayload: NonNullable<PostWorkoutsRequestBody["workout"]> = {
-				title,
-				description: description ?? null,
-				start_time: startTime,
-				end_time: endTime,
-				is_private: isPrivate,
-				exercises: exercises.map(
-					(exercise): PostWorkoutsRequestExercise => ({
-						exercise_template_id: exercise.exerciseTemplateId,
-						superset_id: exercise.supersetId ?? null,
-						notes: exercise.notes ?? null,
-						sets: exercise.sets.map((set) => ({
-							type: set.type as PostWorkoutsRequestSetTypeEnumKey,
-							weight_kg: convertWeightToKg(set),
-							reps: set.reps ?? null,
-							distance_meters: set.distance ?? set.distanceMeters ?? null,
-							duration_seconds: set.duration ?? set.durationSeconds ?? null,
-							rpe: (set.rpe as PostWorkoutsRequestSetRpeEnumKey | null) ?? null,
-							custom_metric: set.customMetric ?? null,
-						})),
-					}),
-				),
-			};
-			const requestBody: PostWorkoutsRequestBody = { workout: workoutPayload };
+			const { workoutId } = args;
+			const requestBody = buildWorkoutPayload(args);
 
 			const data: PutV1WorkoutsWorkoutid200 = await hevyClient.updateWorkout(
 				workoutId,
@@ -311,10 +290,7 @@ export function registerWorkoutTools(
 			}
 
 			const workout = formatWorkout(data);
-			return createJsonResponse(workout, {
-				pretty: true,
-				indent: 2,
-			});
+			return createJsonResponse(workout);
 		}, "update-workout-operation"),
 	);
 }


### PR DESCRIPTION
## Summary
- Extract `buildWorkoutPayload()` helper to deduplicate create/update workout payload construction (-35 lines)
- Extract `mapRoutineExercises()` and `buildRoutineResponse()` helpers for routines (-27 lines)
- Simplify `.map()` calls to point-free style across all tool files
- Remove redundant type annotations, `String()` casts, unused imports, and default options

## Test plan
- [x] `pnpm run check` — Biome formatting/linting passes
- [x] `pnpm run check:types` — TypeScript type checking passes
- [x] 174 unit tests pass (no behavioral changes)
- [x] Reviewed by codex and gemini (both approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)