### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
 				"package": "@daveremy/hevy-mcp"
 			},
 			"description": "MCP server for the Hevy fitness tracking API",
-			"version": "0.1.3"
+			"version": "0.2.0"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "hevy-mcp",
 	"description": "MCP server for the Hevy fitness tracking API — workouts, routines, exercises, and more",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"author": {
 		"name": "daveremy"
 	},
@@ -10,10 +10,7 @@
 	"mcpServers": {
 		"hevy-mcp": {
 			"command": "npx",
-			"args": [
-				"-y",
-				"@daveremy/hevy-mcp"
-			]
+			"args": ["-y", "@daveremy/hevy-mcp"]
 		}
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `@daveremy/hevy-mcp` will be documented in this file.
 
 For the upstream changelog (chrisdoc/hevy-mcp v1.0.0–v1.20.10), see [the original repo](https://github.com/chrisdoc/hevy-mcp/blob/main/CHANGELOG.md).
 
+## [0.2.0](https://github.com/daveremy/hevy-mcp/compare/v0.1.3...v0.2.0) (2026-03-12)
+
+### Features
+
+* **exercise template search**: add optional `search`, `muscleGroup`, and `type` filters to `get-exercise-templates` with in-memory cache (5-min TTL, concurrent page fetching) ([#5](https://github.com/daveremy/hevy-mcp/pull/5)), closes [#2](https://github.com/daveremy/hevy-mcp/issues/2)
+* **pagination metadata**: include `page` and `page_count` in all paginated tool responses (workouts, routines, exercise templates, routine folders, workout events) ([#6](https://github.com/daveremy/hevy-mcp/pull/6)), closes [#4](https://github.com/daveremy/hevy-mcp/issues/4)
+* **create-exercise-template**: return full template details (id, title, type, equipment, muscles) so callers can use it immediately ([#6](https://github.com/daveremy/hevy-mcp/pull/6)), closes [#3](https://github.com/daveremy/hevy-mcp/issues/3)
+
+### Refactors
+
+* extract shared helpers (`buildWorkoutPayload`, `mapRoutineExercises`, `buildRoutineResponse`) to deduplicate create/update handlers ([#7](https://github.com/daveremy/hevy-mcp/pull/7))
+* extract shared `muscleGroupEnum` and `exerciseTypeEnum` constants to eliminate duplication
+
 ## [0.1.1](https://github.com/daveremy/hevy-mcp/compare/v0.1.0...v0.1.1) (2026-03-12)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@daveremy/hevy-mcp",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"main": "dist/index.mjs",
 	"module": "src/index.ts",
 	"types": "dist/index.d.mts",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0 in package.json, plugin.json, and marketplace.json
- Add CHANGELOG entry for 0.2.0

## What's in 0.2.0
- **Exercise template search**: `search`, `muscleGroup`, `type` filters on `get-exercise-templates` (#5, closes #2)
- **Pagination metadata**: `page` and `page_count` in all paginated responses (#6, closes #4)
- **Full create response**: `create-exercise-template` returns complete template details (#6, closes #3)
- **Refactors**: extracted shared helpers, deduplicated code (#7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)